### PR TITLE
fix: update Graduate Research Assistant dates to 2019-2023

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 					</ul>
 				</div>
 				<div class="experience-role">
-					<h5><strong>Graduate Research Assistant</strong>, Rensselaer Polytechnic Institute <span class="text-muted">| 2019-2021</span></h5>
+					<h5><strong>Graduate Research Assistant</strong>, Rensselaer Polytechnic Institute <span class="text-muted">| 2019-2023</span></h5>
 					<ul>
 						<li>Collaborated with <strong>cross-functional teams</strong> in data science, engineering, privacy, and fairness to develop <strong>4 production-ready software applications</strong> across <strong>40% of the development cycle</strong>.</li>
 						<li>Analyzed <strong>large-scale private Electronic Healthcare Records data</strong> on secure cloud servers for statistical analysis, exploratory data analysis, ML model training, and visualization across <strong>300,000 records</strong> and <strong>100 features</strong>.</li>


### PR DESCRIPTION
This PR updates the end date for the Graduate Research Assistant role at RPI from 2021 to 2023 to accurately reflect the duration of the position.